### PR TITLE
chore(conf): add org Renovate config via extends

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,4 @@
+{
+  extends: ["github>reqstool/.github//.github/renovate.json5"],
+}
+


### PR DESCRIPTION
## Summary

Adds \`renovate.json5\` extending the org-wide Renovate config from \`reqstool/.github\`.

## Dependency

Requires [reqstool/.github#10](https://github.com/reqstool/.github/pull/10) to be merged first.