### PR TITLE
refactor(ci): update centralized workflow references to common- prefix

### DIFF
--- a/.github/workflows/check-semantic-pr.yml
+++ b/.github/workflows/check-semantic-pr.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   check:
-    uses: reqstool/.github/.github/workflows/check-semantic-pr.yml@e1d67194373e4da7ccfdf400f46201f18ca14f23 # main 2026-03-07
+    uses: reqstool/.github/.github/workflows/common-check-semantic-pr.yml@e1d67194373e4da7ccfdf400f46201f18ca14f23 # main 2026-03-07


### PR DESCRIPTION
## Summary

Follow-up to reqstool/.github#31 — `check-semantic-pr.yml` and/or `build-docs.yml` were renamed to `common-check-semantic-pr.yml` and `common-build-docs.yml` as part of flattening the centralized workflow directory structure (GitHub Actions does not support subdirectory paths for cross-repo reusable workflow references).

## Test plan

- [x] Merge reqstool/.github#31 first
- [x] Merge this PR
- [x] Verify CI passes on a subsequent PR in this repo