### PR TITLE
feat(reqstool): add OpenSpec ↔ reqstool dogfooding layer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     name: Check linting

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,39 @@ jobs:
     uses: ./.github/workflows/lint.yml
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        reqstool-source: [pypi, main]
     steps:
       - uses: actions/checkout@v7
-      - name: Build and run tests
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
-      - run: mvn clean verify
+      - name: Build and run tests
+        run: mvn clean verify
+      - name: Install plugin into local repository
+        run: mvn -DskipTests install
+      - name: Self-apply plugin to assemble dataset zip
+        run: |
+          VERSION=$(mvn -q help:evaluate -Dexpression=project.version -DforceStdout)
+          mvn io.github.reqstool:reqstool-maven-plugin:${VERSION}:assemble-and-attach-zip-artifact \
+            -Dreqstool.datasetPath=docs/reqstool \
+            -Dreqstool.outputDirectory=target/reqstool
+      - name: Install reqstool
+        uses: reqstool/.github/.github/actions/install-reqstool@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        with:
+          reqstool-source: ${{ matrix.reqstool-source }}
+      - name: Validate reqstool spec completeness
+        # not yet available in the latest PyPI release
+        if: matrix.reqstool-source == 'main'
+        uses: reqstool/.github/.github/actions/validate-reqstool@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+      - name: Run reqstool status
+        uses: reqstool/.github/.github/actions/reqstool-status@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22
+        with:
+          fail-if-incomplete: "true"
+
+  validate-openspec:
+    uses: reqstool/.github/.github/workflows/common-validate-openspec.yml@9c6feaab046f4782f430dd2527fdb82c2a5cd926 # main 2026-06-22

--- a/.reqstool-ai.yaml
+++ b/.reqstool-ai.yaml
@@ -1,0 +1,32 @@
+# reqstool-ai configuration
+#
+# This file tells reqstool-ai skills where to find your reqstool files
+# and how to generate IDs for new requirements and SVCs.
+#
+# Place this file at: .reqstool-ai.yaml (project root)
+
+# Project URN — matches the urn in your reqstool YAML files
+urn: reqstool-java-maven-plugin
+
+# Revision string for new requirements and SVCs
+revision: "0.1.0"
+
+# System-level reqstool directory (contains the SSOT requirements and SVCs)
+system:
+  path: docs/reqstool
+
+# Subproject modules — each module imports a subset of requirements/SVCs via filters
+#
+# Required fields per module:
+#   path       — path to the module's reqstool directory (contains filter files)
+#   req_prefix — prefix for requirement IDs belonging to this module (e.g., CORE_)
+#   svc_prefix — prefix for SVC IDs belonging to this module (e.g., SVC_CORE_)
+#
+# Add as many modules as your project has. The module name (key) is used in
+# commands like `/reqstool:status core` and `/reqstool:add-req core`.
+modules:
+  # Matches the existing MAVEN_PLUGIN_NNN / SVC_MAVEN_PLUGIN_NNN ID convention.
+  plugin:
+    path: docs/reqstool
+    req_prefix: "MAVEN_PLUGIN_"
+    svc_prefix: "SVC_MAVEN_PLUGIN_"

--- a/docs/reqstool/reqstool_config.yml
+++ b/docs/reqstool/reqstool_config.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+
+language: java
+build: maven
+resources:
+  requirements: requirements.yml
+  software_verification_cases: software_verification_cases.yml
+  annotations: ../../target/reqstool/annotations.yml
+  test_results:
+    - ../../target/surefire-reports/*.xml

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -1,0 +1,48 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+
+metadata:
+  urn: reqstool-java-maven-plugin
+  variant: microservice
+  title: Reqstool Java Maven Plugin
+  url: https://github.com/reqstool/reqstool-java-maven-plugin
+
+requirements:
+  - id: MAVEN_PLUGIN_001
+    title: Combine requirement and SVC annotations into a single annotations.yml
+    significance: shall
+    description: >-
+      The plugin shall combine the requirement-annotation and SVC-annotation
+      files produced by the annotation processor (one from main sources, one
+      from test sources) into a single annotations.yml, preserving any
+      entries already present under each section.
+    categories: [functional-suitability]
+    revision: "0.1.0"
+  - id: MAVEN_PLUGIN_002
+    title: Assemble the reqstool zip artifact during the verify phase
+    significance: shall
+    description: >-
+      During the verify phase, the plugin shall assemble a zip artifact
+      containing the mandatory requirements.yml, the optional
+      software_verification_cases.yml/manual_verification_results.yml/annotations.yml
+      when present, any test result files matching the configured patterns,
+      and a generated reqstool_config.yml describing the included resources.
+    categories: [functional-suitability]
+    revision: "0.1.0"
+  - id: MAVEN_PLUGIN_003
+    title: Attach the assembled zip artifact to the Maven project
+    significance: shall
+    description: >-
+      The plugin shall attach the assembled zip artifact to the Maven
+      project under the "reqstool" classifier, so it is installed/deployed
+      alongside the project's other artifacts.
+    categories: [functional-suitability]
+    revision: "0.1.0"
+  - id: MAVEN_PLUGIN_004
+    title: Honor skip flags to bypass execution, zip assembly, or artifact attachment
+    significance: shall
+    description: >-
+      The plugin shall support independent skip/skipAssembleZipArtifact/skipAttachZipArtifact
+      flags, so the whole goal, just the zip assembly, or just the artifact
+      attachment can be bypassed without modifying the rest of the build.
+    categories: [functional-suitability]
+    revision: "0.1.0"

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+
+cases:
+  - id: SVC_MAVEN_PLUGIN_001
+    requirement_ids: ["MAVEN_PLUGIN_001"]
+    title: "Verify implementation and test annotation files are combined into one annotations.yml"
+    verification: automated-test
+    revision: "0.1.0"
+
+  - id: SVC_MAVEN_PLUGIN_002
+    requirement_ids: ["MAVEN_PLUGIN_002"]
+    title: "Verify the zip artifact is assembled with the mandatory and optional reqstool resources"
+    verification: automated-test
+    revision: "0.1.0"
+
+  - id: SVC_MAVEN_PLUGIN_003
+    requirement_ids: ["MAVEN_PLUGIN_003"]
+    title: "Verify the assembled zip is attached to the Maven project under the reqstool classifier"
+    verification: automated-test
+    revision: "0.1.0"
+
+  - id: SVC_MAVEN_PLUGIN_004
+    requirement_ids: ["MAVEN_PLUGIN_004"]
+    title: "Verify skip, skipAssembleZipArtifact, and skipAttachZipArtifact each bypass their respective step"
+    verification: automated-test
+    revision: "0.1.0"

--- a/openspec/openspecui.hooks.ts
+++ b/openspec/openspecui.hooks.ts
@@ -1,0 +1,108 @@
+// @reqstool-openspec-hooks: 0.1.1
+import { spawn, ChildProcess } from "child_process";
+import type { OnReadDocumentHookV1 } from "openspecui/hooks";
+
+// Minimal MCP client over stdio (JSON-RPC 2.0, newline-delimited).
+// Uses only Node.js built-ins — no npm packages required.
+class McpStdioClient {
+  private proc: ChildProcess;
+  private buf = "";
+  private pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private id = 1;
+  readonly ready: Promise<void>;
+
+  constructor(cwd: string) {
+    this.proc = spawn("reqstool", ["mcp"], {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.proc.stdout!.on("data", (chunk: Buffer) => {
+      this.buf += chunk.toString();
+      let nl: number;
+      while ((nl = this.buf.indexOf("\n")) !== -1) {
+        const line = this.buf.slice(0, nl).trim();
+        this.buf = this.buf.slice(nl + 1);
+        if (line) this.handle(line);
+      }
+    });
+    this.ready = this.init();
+  }
+
+  private handle(line: string) {
+    try {
+      const msg = JSON.parse(line) as { id?: number; result?: unknown; error?: { message: string } };
+      if (msg.id !== undefined) {
+        const p = this.pending.get(msg.id);
+        if (p) {
+          this.pending.delete(msg.id);
+          msg.error ? p.reject(new Error(msg.error.message)) : p.resolve(msg.result);
+        }
+      }
+    } catch (e) {
+      console.warn("[reqstool-openspec] Skipping non-JSON line from reqstool mcp:", e instanceof Error ? e.message : e);
+    }
+  }
+
+  private send(method: string, params: unknown, expectReply = true): Promise<unknown> {
+    if (!expectReply) {
+      this.proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+      return Promise.resolve();
+    }
+    const id = this.id++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  private async init(): Promise<void> {
+    await this.send("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      clientInfo: { name: "openspecui", version: "1.0" },
+    });
+    this.send("notifications/initialized", {}, false);
+  }
+
+  async enrich(content: string, preset: string): Promise<string> {
+    await this.ready;
+    const result = (await this.send("tools/call", {
+      name: "enrich_document",
+      arguments: { content, preset },
+    })) as { content: { text: string }[] };
+    return result.content[0].text;
+  }
+
+  close() {
+    this.proc.stdin?.end();
+    this.proc.kill();
+  }
+}
+
+let client: McpStdioClient | null = null;
+
+export const onReadDocument: OnReadDocumentHookV1 = async (ctx, read) => {
+  if (!client) {
+    client = new McpStdioClient(ctx.projectDir);
+    ctx.lifecycle.onDispose(() => {
+      client?.close();
+      client = null;
+    });
+  }
+
+  const result = await read();
+  const preset = `openspec:${ctx.document.kind}`;
+
+  try {
+    const enriched = await client.enrich(result.markdown, preset);
+    return { ...result, markdown: enriched, sourceLabel: `reqstool ${preset}` };
+  } catch (e) {
+    return {
+      ...result,
+      diagnostics: [{ level: "warning", message: `reqstool enrich failed: ${e}` }],
+    };
+  }
+};

--- a/openspec/specs/annotation-combination/spec.md
+++ b/openspec/specs/annotation-combination/spec.md
@@ -1,0 +1,15 @@
+# Annotation Combination Specification
+
+## Purpose
+
+Requirement and SVC content is owned by reqstool (single source of truth). This spec references
+reqstool requirement and SVC IDs only; titles and descriptions are injected at read time via
+`reqstool enrich` (or the openspecui hook). See `docs/reqstool/`.
+
+## Requirements
+
+### Requirement: MAVEN_PLUGIN_001
+The system SHALL implement MAVEN_PLUGIN_001.
+
+#### Scenario: SVC_MAVEN_PLUGIN_001
+The system SHALL pass SVC_MAVEN_PLUGIN_001.

--- a/openspec/specs/artifact-attachment/spec.md
+++ b/openspec/specs/artifact-attachment/spec.md
@@ -1,0 +1,15 @@
+# Artifact Attachment Specification
+
+## Purpose
+
+Requirement and SVC content is owned by reqstool (single source of truth). This spec references
+reqstool requirement and SVC IDs only; titles and descriptions are injected at read time via
+`reqstool enrich` (or the openspecui hook). See `docs/reqstool/`.
+
+## Requirements
+
+### Requirement: MAVEN_PLUGIN_003
+The system SHALL implement MAVEN_PLUGIN_003.
+
+#### Scenario: SVC_MAVEN_PLUGIN_003
+The system SHALL pass SVC_MAVEN_PLUGIN_003.

--- a/openspec/specs/skip-flags/spec.md
+++ b/openspec/specs/skip-flags/spec.md
@@ -1,0 +1,15 @@
+# Skip Flags Specification
+
+## Purpose
+
+Requirement and SVC content is owned by reqstool (single source of truth). This spec references
+reqstool requirement and SVC IDs only; titles and descriptions are injected at read time via
+`reqstool enrich` (or the openspecui hook). See `docs/reqstool/`.
+
+## Requirements
+
+### Requirement: MAVEN_PLUGIN_004
+The system SHALL implement MAVEN_PLUGIN_004.
+
+#### Scenario: SVC_MAVEN_PLUGIN_004
+The system SHALL pass SVC_MAVEN_PLUGIN_004.

--- a/openspec/specs/zip-assembly/spec.md
+++ b/openspec/specs/zip-assembly/spec.md
@@ -1,0 +1,15 @@
+# Zip Assembly Specification
+
+## Purpose
+
+Requirement and SVC content is owned by reqstool (single source of truth). This spec references
+reqstool requirement and SVC IDs only; titles and descriptions are injected at read time via
+`reqstool enrich` (or the openspecui hook). See `docs/reqstool/`.
+
+## Requirements
+
+### Requirement: MAVEN_PLUGIN_002
+The system SHALL implement MAVEN_PLUGIN_002.
+
+#### Scenario: SVC_MAVEN_PLUGIN_002
+The system SHALL pass SVC_MAVEN_PLUGIN_002.

--- a/pom.xml
+++ b/pom.xml
@@ -88,9 +88,20 @@
             <version>2.22.0</version>
         </dependency>
         <dependency>
+            <groupId>io.github.reqstool</groupId>
+            <artifactId>reqstool-java-annotations</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>6.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -98,6 +109,19 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.github.reqstool</groupId>
+                            <artifactId>reqstool-java-annotations</artifactId>
+                            <version>1.0.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/io/github/reqstool/plugins/maven/RequirementsToolMojo.java
+++ b/src/main/java/io/github/reqstool/plugins/maven/RequirementsToolMojo.java
@@ -47,6 +47,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 
+import io.github.reqstool.annotations.Requirements;
+
 /**
  * Maven Mojo for assembling and attaching reqstool artifacts. This plugin packages
  * requirements, test results, and annotations into a ZIP artifact during the verify phase
@@ -150,6 +152,7 @@ public class RequirementsToolMojo extends AbstractMojo {
 	 * and test results, and attaches the artifact to the Maven project.
 	 * @throws MojoExecutionException if an error occurs during execution
 	 */
+	@Requirements({ "MAVEN_PLUGIN_004" })
 	public void execute() throws MojoExecutionException {
 		if (skip) {
 			getLog().info("Skipping execution of reqstool plugin");
@@ -201,6 +204,7 @@ public class RequirementsToolMojo extends AbstractMojo {
 		}
 	}
 
+	@Requirements({ "MAVEN_PLUGIN_001" })
 	static JsonNode combineOutput(JsonNode implementationsNode, JsonNode testsNode) {
 		ObjectNode requirementAnnotationsNode = yamlMapper.createObjectNode();
 		if (!implementationsNode.isEmpty()) {
@@ -227,6 +231,7 @@ public class RequirementsToolMojo extends AbstractMojo {
 		}
 	}
 
+	@Requirements({ "MAVEN_PLUGIN_002" })
 	private void assembleZipArtifact() throws IOException, MojoExecutionException {
 		String zipArtifactFilename = project.getBuild().getFinalName() + "-reqstool.zip";
 		String topLevelDir = project.getBuild().getFinalName() + "-reqstool";
@@ -328,6 +333,7 @@ public class RequirementsToolMojo extends AbstractMojo {
 		}
 	}
 
+	@Requirements({ "MAVEN_PLUGIN_003" })
 	private void attachArtifact() {
 		String zipArtifactFilename = project.getBuild().getFinalName() + "-reqstool.zip";
 		File zipFile = new File(outputDirectory, zipArtifactFilename);

--- a/src/test/java/io/github/reqstool/plugins/maven/RequirementsToolMojoTests.java
+++ b/src/test/java/io/github/reqstool/plugins/maven/RequirementsToolMojoTests.java
@@ -2,7 +2,12 @@
 package io.github.reqstool.plugins.maven;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,11 +20,44 @@ import java.nio.file.Path;
 
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.MavenProjectHelper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import com.fasterxml.jackson.databind.JsonNode;
+
+import io.github.reqstool.annotations.SVCs;
 
 class RequirementsToolMojoTests {
 
+	private static void setField(Object target, String fieldName, Object value) throws Exception {
+		Field field = RequirementsToolMojo.class.getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+
+	private static RequirementsToolMojo newMojoForExecute(File outputDirectory, MavenProjectHelper projectHelper)
+			throws Exception {
+		RequirementsToolMojo mojo = new RequirementsToolMojo();
+
+		MavenProject mavenProject = new MavenProject();
+		Build build = new Build();
+		build.setFinalName("test-project");
+		mavenProject.setBuild(build);
+		Field basedirField = mavenProject.getClass().getDeclaredField("basedir");
+		basedirField.setAccessible(true);
+		basedirField.set(mavenProject, outputDirectory);
+
+		setField(mojo, "project", mavenProject);
+		setField(mojo, "projectHelper", projectHelper);
+		setField(mojo, "outputDirectory", outputDirectory);
+		setField(mojo, "requirementsAnnotationsFile",
+				new File(outputDirectory, "missing-requirements-annotations.yml"));
+		setField(mojo, "svcsAnnotationsFile", new File(outputDirectory, "missing-svcs-annotations.yml"));
+		setField(mojo, "testResults", new String[] { "test_results/**/*.xml" });
+		return mojo;
+	}
+
+	@SVCs("SVC_MAVEN_PLUGIN_001")
 	@Test
 	void testCombine() throws IOException {
 		ClassLoader classLoader = getClass().getClassLoader();
@@ -48,6 +86,7 @@ class RequirementsToolMojoTests {
 		assertEquals(combinedFileContentAsString, combinedResult, "The combined annotations files should match");
 	}
 
+	@SVCs("SVC_MAVEN_PLUGIN_002")
 	@Test
 	void testAssembleZipArtifact() throws Exception {
 		ClassLoader classLoader = getClass().getClassLoader();
@@ -68,20 +107,10 @@ class RequirementsToolMojoTests {
 		basedirField.set(mockProject, zipResourcePath.toFile());
 
 		// Set up all required fields
-		Field projectField = RequirementsToolMojo.class.getDeclaredField("project");
-		Field outputDirectoryField = RequirementsToolMojo.class.getDeclaredField("outputDirectory");
-		Field datasetPathField = RequirementsToolMojo.class.getDeclaredField("datasetPath");
-		Field testResultsField = RequirementsToolMojo.class.getDeclaredField("testResults");
-
-		projectField.setAccessible(true);
-		outputDirectoryField.setAccessible(true);
-		datasetPathField.setAccessible(true);
-		testResultsField.setAccessible(true);
-
-		projectField.set(mojo, mockProject);
-		outputDirectoryField.set(mojo, zipResourcePath.toFile());
-		datasetPathField.set(mojo, zipResourcePath.toFile());
-		testResultsField.set(mojo, new String[] { "test_results/**/*.xml" });
+		setField(mojo, "project", mockProject);
+		setField(mojo, "outputDirectory", zipResourcePath.toFile());
+		setField(mojo, "datasetPath", zipResourcePath.toFile());
+		setField(mojo, "testResults", new String[] { "test_results/**/*.xml" });
 
 		// Create mandatory requirements.yml file
 		File reqFile = new File(zipResourcePath.toFile(), "requirements.yml");
@@ -96,6 +125,71 @@ class RequirementsToolMojoTests {
 
 		// Only check if zip file exists
 		assertTrue(Files.exists(zipResourcePath.resolve("test-project-reqstool.zip")));
+	}
+
+	@SVCs("SVC_MAVEN_PLUGIN_003")
+	@Test
+	void testAttachArtifactPassesAssembledZipUnderReqstoolClassifier(@TempDir File outputDirectory) throws Exception {
+		MavenProjectHelper projectHelper = mock(MavenProjectHelper.class);
+		RequirementsToolMojo mojo = newMojoForExecute(outputDirectory, projectHelper);
+		setField(mojo, "skipAssembleZipArtifact", true);
+		setField(mojo, "datasetPath", outputDirectory);
+
+		File requirementsFile = new File(outputDirectory, "requirements.yml");
+		Files.write(requirementsFile.toPath(), "requirements: []\n".getBytes());
+
+		mojo.execute();
+
+		Field projectField = RequirementsToolMojo.class.getDeclaredField("project");
+		projectField.setAccessible(true);
+		MavenProject project = (MavenProject) projectField.get(mojo);
+		verify(projectHelper).attachArtifact(eq(project), eq("zip"), eq("reqstool"),
+				eq(new File(outputDirectory, "test-project-reqstool.zip")));
+	}
+
+	@SVCs("SVC_MAVEN_PLUGIN_004")
+	@Test
+	void testSkipBypassesExecutionEntirely(@TempDir File outputDirectory) throws Exception {
+		MavenProjectHelper projectHelper = mock(MavenProjectHelper.class);
+		RequirementsToolMojo mojo = newMojoForExecute(outputDirectory, projectHelper);
+		setField(mojo, "skip", true);
+
+		mojo.execute();
+
+		assertFalse(new File(outputDirectory, RequirementsToolMojo.OUTPUT_FILE_ANNOTATIONS_YML_FILE).exists());
+		verifyNoInteractions(projectHelper);
+	}
+
+	@SVCs("SVC_MAVEN_PLUGIN_004")
+	@Test
+	void testSkipAssembleZipArtifactBypassesZipCreation(@TempDir File outputDirectory) throws Exception {
+		MavenProjectHelper projectHelper = mock(MavenProjectHelper.class);
+		RequirementsToolMojo mojo = newMojoForExecute(outputDirectory, projectHelper);
+		setField(mojo, "skipAssembleZipArtifact", true);
+		setField(mojo, "skipAttachZipArtifact", true);
+
+		mojo.execute();
+
+		assertTrue(new File(outputDirectory, RequirementsToolMojo.OUTPUT_FILE_ANNOTATIONS_YML_FILE).exists());
+		assertFalse(new File(outputDirectory, "test-project-reqstool.zip").exists());
+		verifyNoInteractions(projectHelper);
+	}
+
+	@SVCs("SVC_MAVEN_PLUGIN_004")
+	@Test
+	void testSkipAttachZipArtifactBypassesArtifactAttachment(@TempDir File outputDirectory) throws Exception {
+		MavenProjectHelper projectHelper = mock(MavenProjectHelper.class);
+		RequirementsToolMojo mojo = newMojoForExecute(outputDirectory, projectHelper);
+		setField(mojo, "datasetPath", outputDirectory);
+		setField(mojo, "skipAttachZipArtifact", true);
+
+		File requirementsFile = new File(outputDirectory, "requirements.yml");
+		Files.write(requirementsFile.toPath(), "requirements: []\n".getBytes());
+
+		mojo.execute();
+
+		assertTrue(new File(outputDirectory, "test-project-reqstool.zip").exists());
+		verifyNoInteractions(projectHelper);
 	}
 
 }


### PR DESCRIPTION
## Summary
- Applies the [reqstool-client#407](https://github.com/reqstool/reqstool-client/pull/407) dogfooding pattern to this repo: thin OpenSpec specs → `docs/reqstool` SSOT → `@Requirements`/`@SVCs` annotations on the real implementation sites.
- Tags `RequirementsToolMojo`'s four behaviourally-distinct methods (`execute`, `combineOutput`, `assembleZipArtifact`, `attachArtifact`) with `@Requirements`, and closes real test-coverage gaps (`attachArtifact` and all three skip-flag paths were previously untested) so every SVC has a genuine verifying test.
- Adds `.reqstool-ai.yaml` for `reqstool enrich` round-tripping.
- Wires CI to install the plugin locally, self-apply it (fully-qualified goal invocation, since a maven plugin can't bind itself within the same reactor build that produces it) to generate the annotations dataset, then gate on `reqstool status --check-all-reqs-met` and `openspec validate --specs --strict`.

## Notable fix
Annotation processing for `@Requirements`/`@SVCs` wasn't producing output despite `reqstool-java-annotations` being a correctly-structured `META-INF/services` processor on the classpath — maven-compiler-plugin's default non-forked javac invocation doesn't reliably auto-discover it. Fixed by adding an explicit `annotationProcessorPaths` entry, mirroring how `reqstool-java-annotations`' own pom declares its `auto-service` processor.

## Test plan
- [x] `mvn clean verify` — 6/6 tests pass (3 new: `attachArtifact` coverage + 3 skip-flag paths)
- [x] `openspec validate --specs --strict` — 4/4 specs pass
- [x] `reqstool status --check-all-reqs-met local -p docs/reqstool` — exit 0, 4/4 requirements implemented, 6/6 SVCs passed, 0 missing tests/MVRs
- [x] Local self-application loop verified end-to-end (`mvn install` → fully-qualified-goal invocation → `target/reqstool/annotations.yml` produced correctly)