### PR TITLE
fix(build): declare the extensions.xml namespace so Renovate tracks Nisse

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extensions>
+<!-- The xmlns is load-bearing: Renovate's maven manager skips an extensions.xml
+     without a recognised EXTENSIONS namespace, so without it Nisse is never
+     updated. -->
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 https://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
     <!-- Derives ${nisse.jgit.dynamicVersion} from git state, so the tag is the
          only version. See RELEASING.md in reqstool/.github. -->
     <extension>


### PR DESCRIPTION
ⓘ Follow-up to the git-derived versioning change. Small, but it is the difference between Nisse being maintained and never being updated again.

## What & Why

Renovate parses `.mvn/extensions.xml` by default — it is in the maven manager’s default file patterns. But it **rejects the file outright unless the root element carries a recognised namespace**. From [`lib/modules/manager/maven/extract.ts`](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/maven/extract.ts):

```ts
const supportedExtensionsNamespaces = [
  "http://maven.apache.org/EXTENSIONS/1.0.0",
  "http://maven.apache.org/EXTENSIONS/1.1.0",
  "http://maven.apache.org/EXTENSIONS/1.2.0",
];

function parseExtensions(raw: string, packageFile: string): XmlDocument | null {
  ...
  if (!supportedExtensionsNamespaces.includes(attr.xmlns)) {
    return null;      // <- file silently skipped
  }
```

Ours declared **no `xmlns` at all**, so `attr.xmlns` was `undefined`, the file was skipped, and **Nisse would have sat at 0.9.5 indefinitely** while every other dependency in the repo kept moving. No warning, no PR, nothing to notice — exactly the kind of silent rot pinning a version is meant to prevent.

(0.9.5 is current as of today — released 2026-08-10. The problem is the future, not the present.)

## Verification

The namespace is not just cosmetic to Maven, so I checked it does not change resolution:

```
git tag 9.9.9
mvn --batch-mode help:evaluate -Dexpression=project.version -q -DforceStdout
→ 9.9.9
```

Unchanged. CI on this PR builds the project for real.

## Author checklist

- [x] Verified against Renovate’s actual source, not just its docs
- [x] Verified Maven still resolves the git-derived version
- [x] Conventional Commit title, DCO sign-off